### PR TITLE
Publish poses to /tf in ROSOutput3DWrapper

### DIFF
--- a/lsd_slam/CMakeLists.txt
+++ b/lsd_slam/CMakeLists.txt
@@ -1,2 +1,4 @@
+cmake_minimum_required(VERSION 2.8.3)
 project(lsd_slam)
+find_package(catkin REQUIRED)
 catkin_package()

--- a/lsd_slam_core/CMakeLists.txt
+++ b/lsd_slam_core/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(lsd_slam_core)
 # Load catkin and all dependencies required for this package
 # TODO: remove all from COMPONENTS that are not catkin packages.
-find_package(catkin REQUIRED COMPONENTS cv_bridge dynamic_reconfigure sensor_msgs roslib rosbag lsd_slam_viewer roscpp)
+find_package(catkin REQUIRED COMPONENTS cv_bridge dynamic_reconfigure sensor_msgs roslib rosbag lsd_slam_viewer roscpp tf)
 
 # include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 # CATKIN_MIGRATION: removed during catkin migration

--- a/lsd_slam_core/src/IOWrapper/ROS/ROSOutput3DWrapper.h
+++ b/lsd_slam_core/src/IOWrapper/ROS/ROSOutput3DWrapper.h
@@ -22,6 +22,7 @@
 
 #include <ros/ros.h>
 #include "IOWrapper/Output3DWrapper.h"
+#include <tf/transform_broadcaster.h>
 
 
 namespace lsd_slam
@@ -95,9 +96,10 @@ private:
 	std::string debugInfo_channel;
 	ros::Publisher debugInfo_publisher;
 
-
 	std::string pose_channel;
 	ros::Publisher pose_publisher;
+
+	tf::TransformBroadcaster tf_publisher_;
 
 	ros::NodeHandle nh_;
 };


### PR DESCRIPTION
Publish poses to /tf in ROSOutput3DWrapper so that LSD_SLAM can be used with depthest_ros
Add tf to the required components in CMakeLists.txt